### PR TITLE
Add a typedef for ofxJSON -> ofxJSONElement

### DIFF
--- a/src/ofxJSONElement.h
+++ b/src/ofxJSONElement.h
@@ -13,12 +13,14 @@
 
 #pragma once
 
-
 #include <string>
 #include "json/json.h"
 #include "ofLog.h"
 #include "ofURLFileLoader.h"
 
+// Add a typedef for a shorter type name
+class ofxJSONElement;
+typedef ofxJSONElement ofxJSON;
 
 class ofxJSONElement: public Json::Value
 {


### PR DESCRIPTION
I've always found `ofxJSONElement` to be unnecessarily long – is there a reason it isn't simply `ofxJSON`/`ofxJson`?

I end up doing this typedef in some projects and figured others like it. If this is :+1: we could also rename to ofxJSON and add ofxJSONElement as a typedef for compatibility with existing projects?